### PR TITLE
add rerank & redis cache

### DIFF
--- a/server/src/utils/cache.ts
+++ b/server/src/utils/cache.ts
@@ -1,0 +1,67 @@
+import Redis from "ioredis";
+import crypto from "crypto";
+import { parseRedisUrl } from "./redis";
+
+let redisClient: Redis | null = null;
+
+function getRedis(): Redis | null {
+  try {
+    if (redisClient) return redisClient;
+    const redis_url = process.env.DB_REDIS_URL || process.env.REDIS_URL;
+    if (!redis_url) return null;
+    const parsed = parseRedisUrl(redis_url);
+    if (!parsed) return null;
+    redisClient = new Redis({
+      host: parsed.host,
+      port: parsed.port,
+      password: parsed.password,
+      username: process?.env?.DB_REDIS_USERNAME,
+      lazyConnect: true,
+      maxRetriesPerRequest: 1,
+    });
+    // Best-effort connect
+    redisClient.connect().catch(() => undefined);
+    return redisClient;
+  } catch {
+    return null;
+  }
+}
+
+export function stableHash(input: unknown): string {
+  const json = typeof input === "string" ? input : JSON.stringify(input);
+  return crypto.createHash("sha1").update(json).digest("hex");
+}
+
+export function makeKey(parts: (string | number | boolean | null | undefined)[]): string {
+  return parts.map((p) => String(p ?? "")).join(":");
+}
+
+export async function getJson<T>(key: string): Promise<T | null> {
+  const r = getRedis();
+  if (!r) return null;
+  try {
+    const val = await r.get(key);
+    if (!val) return null;
+    return JSON.parse(val) as T;
+  } catch {
+    return null;
+  }
+}
+
+export async function setJsonTTL(key: string, value: unknown, ttlSeconds?: number): Promise<void> {
+  const r = getRedis();
+  if (!r) return;
+  try {
+    const payload = JSON.stringify(value);
+    const ttl = ttlSeconds ?? Number(process.env.DB_CACHE_TTL_S || 600);
+    if (ttl > 0) {
+      await r.setex(key, ttl, payload);
+    } else {
+      await r.set(key, payload);
+    }
+  } catch {
+    // ignore
+  }
+}
+
+


### PR DESCRIPTION
我把 Cohere 重排集成到了 DialoqbaseHybridRetrival，用环境变量开关，且带 span。接下来我会补一个简单缓存中间件（召回/生成两级），默认可关。
如何启用/验证重排
环境变量
DB_USE_RERANK=true
COHERE_API_KEY=*******
可选：COHERE_RERANK_MODEL=rerank-english-v3.0
请求路径
正常走你现有接口即可；在检索后会自动触发重排并排序候选。
观察
Trace 中会出现 retrieval.rerank span
评测脚本输出的 latency_ms 会反映重排带来的开销（可与关闭对比）
我准备继续实现缓存
召回级缓存（key: bot_id+query hash+data_version），命中后跳过向量/关键词检索与重排。
生成级缓存（key: model+prompt hash+context hash），命中后直接返回生成文本。
指标：cache_hit_total 自增；直方图看延迟收益。
需要我直接加缓存实现吗，还是先跑一次离线评测对比“开启重排 vs 关闭重排”的结果？



我已加好两级缓存：检索级和生成级，命中会自增缓存指标。默认使用 DB_REDIS_URL/REDIS_URL，TTL 可用 DB_CACHE_TTL_S 控制。
如何使用
环境变量
DB_REDIS_URL=redis://:password@host:6379/0
可选 DB_CACHE_TTL_S=600
命中行为
检索级：复用候选文档，避免重复向量/关键词检索与重排
生成级：复用最终回复与引用
指标：命中会触发 cache_hit_total 自增
你可以直接启动服务并回放相同 Query，观察两次的延迟差异与 /metrics 的命中计数。
简要变更
新增 server/src/utils/cache.ts：Redis 客户端与 getJson/setJsonTTL、稳定哈希
修改 chat.handler.ts：在生成与检索处接入缓存；命中直接返回
无 lint 问题
要不要我继续做 Prompt 模板版本化与 JSON Schema 校验，还是先跑离线评测对比“开启重排/缓存前后”的效果？