### PR TITLE
智能体编排样例：工具化检索 + Orchestrator + Summarize Pipeline

### DIFF
--- a/server/src/agents/orchestrator.ts
+++ b/server/src/agents/orchestrator.ts
@@ -1,0 +1,44 @@
+import { AgentContext, AgentMessage, Tool } from "./types";
+import { startSpan, endSpan } from "../observability/metrics-helpers";
+
+export class Orchestrator {
+  private tools: Record<string, Tool>;
+  constructor(tools: Tool[]) {
+    this.tools = Object.fromEntries(tools.map((t) => [t.name, t]));
+  }
+
+  async runPipeline(
+    ctx: AgentContext,
+    plan: Array<{ role: string; tool?: string; prompt?: string }>
+  ): Promise<AgentMessage[]> {
+    const span = startSpan("agents.orchestrator.run", { botId: ctx.botId });
+    const transcript: AgentMessage[] = [];
+    try {
+      for (const step of plan) {
+        if (step.tool) {
+          const tool = this.tools[step.tool];
+          if (!tool) continue;
+          const input = { query: this.lastUserMessage(ctx) };
+          const res = await tool.call(input, ctx);
+          transcript.push({ role: "tool", content: JSON.stringify(res), meta: { tool: step.tool } });
+          ctx.history.push({ role: "tool", content: JSON.stringify(res), meta: { tool: step.tool } });
+        } else if (step.prompt) {
+          transcript.push({ role: "assistant", content: step.prompt });
+          ctx.history.push({ role: "assistant", content: step.prompt });
+        }
+      }
+      return transcript;
+    } finally {
+      endSpan(span);
+    }
+  }
+
+  private lastUserMessage(ctx: AgentContext): string {
+    for (let i = ctx.history.length - 1; i >= 0; i--) {
+      if (ctx.history[i].role === "user") return ctx.history[i].content;
+    }
+    return "";
+  }
+}
+
+

--- a/server/src/agents/pipelines/summarize.ts
+++ b/server/src/agents/pipelines/summarize.ts
@@ -1,0 +1,17 @@
+import { Orchestrator } from "../orchestrator";
+import { retrieveTool } from "../tools/retrieve";
+import { AgentContext, AgentMessage } from "../types";
+
+export async function runSummarizePipeline(ctx: AgentContext): Promise<AgentMessage[]> {
+  const plan = [
+    { role: "assistant", prompt: "Researcher: I will retrieve relevant context." },
+    { role: "assistant", prompt: "Retriever: fetching docs..." },
+    { role: "tool", tool: "retrieve" },
+    { role: "assistant", prompt: "Writer: I will write a concise summary based on retrieved docs." },
+  ];
+  const orch = new Orchestrator([retrieveTool]);
+  const transcript = await orch.runPipeline(ctx, plan);
+  return transcript;
+}
+
+

--- a/server/src/agents/tools/retrieve.ts
+++ b/server/src/agents/tools/retrieve.ts
@@ -1,0 +1,29 @@
+import { Tool, AgentContext, ToolResult } from "../types";
+import { embeddings } from "../../utils/embeddings";
+import { getModelInfo } from "../../utils/get-model-info";
+import { createRetriever } from "../../handlers/api/v1/bot/playground/chat.service";
+
+export const retrieveTool: Tool = {
+  name: "retrieve",
+  async call(input: { query: string }, ctx: AgentContext): Promise<ToolResult> {
+    try {
+      const prisma: any = (global as any).__fastify_prisma || null;
+      if (!prisma) return { name: "retrieve", success: false, error: "no prisma" };
+      const bot = await prisma.bot.findFirst({ where: { id: ctx.botId } });
+      if (!bot) return { name: "retrieve", success: false, error: "bot not found" };
+      const embeddingInfo = await getModelInfo({ model: bot.embedding, prisma, type: "all" });
+      const embeddingModel = embeddings(
+        embeddingInfo.model_provider!.toLowerCase(),
+        embeddingInfo.model_id,
+        embeddingInfo?.config
+      );
+      const retriever = await createRetriever(bot, embeddingModel);
+      const docs = await retriever.getRelevantDocuments(input.query);
+      return { name: "retrieve", success: true, output: docs };
+    } catch (e: any) {
+      return { name: "retrieve", success: false, error: String(e?.message || e) };
+    }
+  },
+};
+
+

--- a/server/src/agents/types.ts
+++ b/server/src/agents/types.ts
@@ -1,0 +1,25 @@
+export type AgentMessage = {
+  role: "user" | "assistant" | "tool" | "system";
+  content: string;
+  meta?: Record<string, any>;
+};
+
+export type ToolResult = {
+  name: string;
+  success: boolean;
+  output?: any;
+  error?: string;
+};
+
+export type AgentContext = {
+  botId: string;
+  promptVersion?: string;
+  history: AgentMessage[];
+};
+
+export interface Tool {
+  name: string;
+  call(input: any, ctx: AgentContext): Promise<ToolResult>;
+}
+
+

--- a/server/src/routes/api/v1/bot/playground/root.ts
+++ b/server/src/routes/api/v1/bot/playground/root.ts
@@ -82,6 +82,25 @@ const root: FastifyPluginAsync = async (fastify, _): Promise<void> => {
     },
     updateBotPlaygroundTitleById
   );
+
+  // Minimal multi-agent demo endpoint
+  fastify.post(
+    "/:id/agents/summarize",
+    {
+      onRequest: [fastify.authenticate],
+    },
+    async (request: any, reply: any) => {
+      const { runSummarizePipeline } = await import("../../../../../agents/pipelines/summarize");
+      const ctx = {
+        botId: request.params.id,
+        history: [{ role: "user", content: request.body?.message || "" }],
+        promptVersion: (request.query as any)?.prompt_version,
+      };
+      (global as any).__fastify_prisma = (request as any).server.prisma;
+      const transcript = await runSummarizePipeline(ctx);
+      return { transcript };
+    }
+  );
 };
 
 export default root;


### PR DESCRIPTION
我已加好一个最小多智能体编排样例：工具化检索 + Orchestrator + Summarize Pipeline，并新增了接口。
怎么用
路由
POST /api/v1/bot/playground/:id/agents/summarize
Body: { "message": "请概述xxx" }
认证与现有 playground 一致
行为
Orchestrator 串联步骤：Researcher→Retriever(工具)→Writer 提示
目前演示检索调用与编排轨迹，便于展示“多Agent流水线”的结构与可扩展位
观测
Trace 中可看到 agents.orchestrator.run
如需扩展，可为每个 Agent 步骤加独立 span/metrics
代码位置
server/src/agents/types.ts：消息/上下文/工具约束
server/src/agents/orchestrator.ts：轻量 Orchestrator
server/src/agents/tools/retrieve.ts：复用现有检索
server/src/agents/pipelines/summarize.ts：简单流水线
server/src/routes/api/v1/bot/playground/root.ts：新路由
下一步可选
增加“写手/校对员”真实 LLM 步骤与输出 Schema 校验
将流水线结果纳入离线评测，对比单Agent vs 多Agent 的准确率/幻觉率/时延/成本，并在 /metrics 中按标签区分统计