### PR TITLE
补完 K8s 清单, 带就绪/存活探针与关键 env，便于滚动发布与回滚。

### DIFF
--- a/docs/k8s/README.md
+++ b/docs/k8s/README.md
@@ -1,0 +1,33 @@
+Deploy Dialoqbase on Kubernetes
+
+Quick start with Helm
+
+```bash
+helm upgrade --install dbase ./helm/dialoqbase \
+  --set image.repository=your-registry/dialoqbase \
+  --set image.tag=latest \
+  --set ingress.hosts[0].host=dialoqbase.local
+```
+
+Resources and Probes
+- Requests: 250m CPU / 512Mi RAM; Limits: 1 CPU / 2Gi RAM
+- Readiness/Liveness: `/docs` endpoint
+
+Env and Secrets
+- See `values.yaml`: `env` for non-sensitive; `secretEnv` for sensitive
+- Important: `DATABASE_URL`, `REDIS_URL`, model API keys
+
+Scaling and SLO
+- HPA targets 70% CPU; adjust based on `/metrics` P95 latency
+- Suggested SLO: P95 < 1500ms for standard QA; Availability 99.9%
+- Monitor: `pipeline_latency_ms`, `llm_token_cost_usd`, `cache_hit_total`, `pipeline_fail_reason_total`
+
+Canary / Rollback
+- Use `helm upgrade` with small `replicaCount` bump
+- Rollback: `helm rollback dbase <REVISION>`
+
+OTEL / Metrics
+- OTLP endpoint default: `http://otel-collector:4318/v1/traces`
+- Scrape `/metrics` via Prometheus
+
+

--- a/helm/dialoqbase/Chart.yaml
+++ b/helm/dialoqbase/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: dialoqbase
+description: Helm chart for Dialoqbase server
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+

--- a/helm/dialoqbase/templates/_helpers.tpl
+++ b/helm/dialoqbase/templates/_helpers.tpl
@@ -1,0 +1,12 @@
+{{- define "dialoqbase.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "dialoqbase.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "dialoqbase.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+

--- a/helm/dialoqbase/templates/deployment.yaml
+++ b/helm/dialoqbase/templates/deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "dialoqbase.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "dialoqbase.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "dialoqbase.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "dialoqbase.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: server
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 3000
+          env:
+            {{- range $k, $v := .Values.env }}
+            - name: {{ $k }}
+              value: "{{ $v }}"
+            {{- end }}
+          envFrom:
+            - secretRef:
+                name: {{ include "dialoqbase.fullname" . }}
+          readinessProbe:
+            httpGet:
+              path: /docs
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /docs
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+

--- a/helm/dialoqbase/templates/ingress.yaml
+++ b/helm/dialoqbase/templates/ingress.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "dialoqbase.fullname" . }}
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress.className }}
+spec:
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "dialoqbase.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+        {{- end }}
+  {{- end }}
+{{- end }}
+

--- a/helm/dialoqbase/templates/secret.yaml
+++ b/helm/dialoqbase/templates/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "dialoqbase.fullname" . }}
+type: Opaque
+stringData:
+{{- range $k, $v := .Values.secretEnv }}
+  {{ $k }}: "{{ $v }}"
+{{- end }}
+

--- a/helm/dialoqbase/templates/service.yaml
+++ b/helm/dialoqbase/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "dialoqbase.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "dialoqbase.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app.kubernetes.io/name: {{ include "dialoqbase.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: 3000
+

--- a/helm/dialoqbase/values.yaml
+++ b/helm/dialoqbase/values.yaml
@@ -1,0 +1,45 @@
+replicaCount: 2
+
+image:
+  repository: your-registry/dialoqbase
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: dialoqbase.local
+      paths:
+        - path: /
+          pathType: Prefix
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: 1
+    memory: 2Gi
+
+env:
+  NODE_ENV: production
+  DB_QUEUE_CONCURRENCY: "2"
+  DB_QUEUE_THREADS: "false"
+  DB_CACHE_TTL_S: "600"
+  DB_USE_RERANK: "false"
+  OLLAMA_BASE_URL: http://ollama.ollama:11434
+
+secretEnv:
+  DATABASE_URL: "postgresql://user:pass@postgres:5432/dialoqbase"
+  REDIS_URL: "redis://:pass@redis:6379/0"
+  OPENAI_API_KEY: ""
+  ANTHROPIC_API_KEY: ""
+  GOOGLE_API_KEY: ""
+  COHERE_API_KEY: ""
+  DB_SECRET_KEY: change-me
+

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dialoqbase-config
+data:
+  NODE_ENV: "production"
+  OTEL_SERVICE_NAME: "dialoqbase-server"
+  OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "http://otel-collector:4318/v1/traces"
+  DB_QUEUE_CONCURRENCY: "2"
+  DB_QUEUE_THREADS: "false"
+  DB_CACHE_TTL_S: "600"
+  DB_USE_RERANK: "false"
+  OLLAMA_BASE_URL: "http://ollama.ollama:11434"
+

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dialoqbase
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: dialoqbase
+  template:
+    metadata:
+      labels:
+        app: dialoqbase
+    spec:
+      containers:
+        - name: server
+          image: your-registry/dialoqbase:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000
+          envFrom:
+            - configMapRef:
+                name: dialoqbase-config
+            - secretRef:
+                name: dialoqbase-secret
+          readinessProbe:
+            httpGet:
+              path: /docs
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /docs
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1"
+              memory: "2Gi"
+

--- a/k8s/hpa.yaml
+++ b/k8s/hpa.yaml
@@ -1,0 +1,19 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: dialoqbase
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: dialoqbase
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dialoqbase
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+    - host: dialoqbase.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: dialoqbase
+                port:
+                  number: 80
+

--- a/k8s/pdb.yaml
+++ b/k8s/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: dialoqbase-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dialoqbase
+

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dialoqbase-secret
+type: Opaque
+stringData:
+  DATABASE_URL: postgresql://user:pass@postgres:5432/dialoqbase
+  REDIS_URL: redis://:pass@redis:6379/0
+  OPENAI_API_KEY: ""
+  ANTHROPIC_API_KEY: ""
+  GOOGLE_API_KEY: ""
+  COHERE_API_KEY: ""
+  DB_SECRET_KEY: change-me
+

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dialoqbase
+spec:
+  type: ClusterIP
+  selector:
+    app: dialoqbase
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3000
+


### PR DESCRIPTION
我已补完 K8s 清单：k8s/ 下包含 Deployment/Service/Ingress/HPA/ConfigMap/Secret/PDB，带就绪/存活探针与关键 env，便于滚动发布与回滚。
如何部署（示例）
修改镜像：k8s/deployment.yaml 中 image: your-registry/dialoqbase:latest
应用资源：
kubectl apply -f k8s/configmap.yaml -f k8s/secret.yaml
kubectl apply -f k8s/deployment.yaml -f k8s/service.yaml -f k8s/ingress.yaml
kubectl apply -f k8s/hpa.yaml -f k8s/pdb.yaml
本地测试（Ingress）
配置 hosts 指向 dialoqbase.local，或改 Ingress 主机名
回滚
kubectl rollout undo deploy/dialoqbase
你现在具备
可观测：OTel Trace + Prometheus /metrics（P95/成本/缓存命中/失败归因）
评测闭环：离线评测脚手架 + 可回放
重排与混检：Cohere Rerank（开关/模型可配）
缓存：检索/生成两级缓存
Prompt：模板版本化 + JSON Schema 校验 + 灰度
多智能体：最小 Orchestrator + summarize demo
K8s：一键清单，可灰度发布
需要的话，我可以再补一个简单的 Helm Chart 与 docs/k8s/README.md 说明，以及在 /metrics 加上多Agent/单Agent 标签区分，方便你做对比看板。



所有既定任务已完成：可观测、评测脚手架、重排/混检、两级缓存、Prompt 版本化+Schema 校验、多智能体编排样例、K8s 清单。
建议你现在做两件小事验证闭环
跑一次评测对比
开关重排与缓存，执行 python server/test/eval/run_eval.py 产出 server/docs/eval/report.json
看观测面板
打开 /metrics 验证 P95、cache 命中、自定义计数
如使用 Jaeger：确认 Trace 链路与新 span（retrieval.hybrid / retrieval.rerank / pipeline.）
后续可选增强
在 /metrics 增加单/多Agent标签与模型/Prompt版本标签，便于看板维度拆分
加一个 Helm Chart 与 docs/k8s/README.md，补充容量规划与SLO示例
将 LLM token 使用与成本做精确计费（按提供商 usage 字段）并暴露直方图
如果你需要，我可以继续补 Helm Chart 和文档，或者把评测脚本替换为 Ragas/DeepEval 的正式指标输出。




已新增 Helm Chart：helm/dialoqbase/（Chart.yaml、values.yaml、templates/*），以及 docs/k8s/README.md 使用说明与 SLO/伸缩建议。
如何使用
打包部署
helm upgrade --install dbase ./helm/dialoqbase --set image.repository=your-registry/dialoqbase --set image.tag=latest --set ingress.hosts[0].host=dialoqbase.local
配置项
镜像仓库与标签：values.yaml 下 image.*
非敏感环境变量：values.yaml 下 env
敏感变量：values.yaml 下 secretEnv（会渲染为 Secret）
资源与副本：values.yaml 下 replicaCount 与 resources
Ingress：values.yaml 下 ingress.*
探针与缩放
Readiness/Liveness 指向 /docs
HPA 示例在普通 k8s 清单中（如需可迁入 Chart）
观测
OTLP endpoint 默认 http://otel-collector:4318/v1/traces
Prometheus 抓取 /metrics
如果需要，我可以把 HPA/PDB 也模板化进 Helm，或者根据你的集群域名/镜像仓库帮你改好默认值。